### PR TITLE
Add FP8 kernel

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -141,9 +141,9 @@ Benchmark::Benchmark(int argc, const char* argv[]) {
   // Print HIP device information
   std::cout << "Device " << device_number << ": " << device_->getName();
   std::cout << " (" << multiProcessorCount();
-  if (isGfx9())
+  if (isCDNA())
     std::cout << "CUs, ";
-  else if (isGfx11())
+  else if (isRDNA3())
     std::cout << "WGPs, ";
   else
     std::cout << "units, ";
@@ -154,22 +154,42 @@ Benchmark::Benchmark(int argc, const char* argv[]) {
 #endif
 }
 
-// isGfx9 and isGfx11 based on
+// architecture checking code based on
 // https://github.com/ROCm/rocWMMA/blob/develop/samples/common.hpp
-bool Benchmark::isGfx9() {
+bool Benchmark::isCDNA1() {
     hipDeviceProp_t mProps;
     hipGetDeviceProperties(&mProps, *device_);
 
     std::string deviceName(mProps.gcnArchName);
 
-    return ((deviceName.find("gfx908") != std::string::npos)
-            || (deviceName.find("gfx90a") != std::string::npos)
-            || (deviceName.find("gfx940") != std::string::npos)
+    return (deviceName.find("gfx908") != std::string::npos);
+}
+
+bool Benchmark::isCDNA2() {
+    hipDeviceProp_t mProps;
+    hipGetDeviceProperties(&mProps, *device_);
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx90a") != std::string::npos);
+}
+
+bool Benchmark::isCDNA3() {
+    hipDeviceProp_t mProps;
+    hipGetDeviceProperties(&mProps, *device_);
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return ((deviceName.find("gfx940") != std::string::npos)
             || (deviceName.find("gfx941") != std::string::npos)
             || (deviceName.find("gfx942") != std::string::npos));
 }
 
-bool Benchmark::isGfx11() {
+bool Benchmark::isCDNA() {
+    return (isCDNA1() || isCDNA2() || isCDNA3());
+}
+
+bool Benchmark::isRDNA3() {
     hipDeviceProp_t mProps;
     hipGetDeviceProperties(&mProps, *device_);
 

--- a/common.h
+++ b/common.h
@@ -27,8 +27,10 @@ class Benchmark {
  public:
   Benchmark(int argc, const char* argv[]);
 
-  bool isGfx9();
-  bool isGfx11();
+  bool isCDNA();
+  bool isCDNA2();
+  bool isCDNA3();
+  bool isRDNA3();
   void allocate(size_t bytes);
   void run(void* kernel, dim3 grid, dim3 block, const char* name,
            double gops = 0, double gbytes = 0);

--- a/common.h
+++ b/common.h
@@ -28,6 +28,7 @@ class Benchmark {
   Benchmark(int argc, const char* argv[]);
 
   bool isCDNA();
+  bool isCDNA1();
   bool isCDNA2();
   bool isCDNA3();
   bool isRDNA3();

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -7,8 +7,8 @@ using namespace rocwmma;
 
 #define START                                        \
   fragment<accumulator, M, N, K, Tout> sum;          \
-  fragment<matrix_a, M, N, K, Tin, row_major> aFrag; \
-  fragment<matrix_b, M, N, K, Tin, col_major> bFrag; \
+  fragment<matrix_a, M, N, K, Tc, row_major> aFrag; \
+  fragment<matrix_b, M, N, K, Tc, col_major> bFrag; \
   fill_fragment(sum, static_cast<Tout>(0));          \
   fill_fragment(aFrag, static_cast<Tin>(0));         \
   fill_fragment(bFrag, static_cast<Tin>(0));         \
@@ -18,14 +18,14 @@ using namespace rocwmma;
   Tout* ptr = &data[threadIdx.y * M * N]; \
   store_matrix_sync(ptr, sum, N, mem_row_major);
 
-template <typename Tin, typename Tout, unsigned M, unsigned N, unsigned K>
+template <typename Tin, typename Tc, typename Tout, unsigned M, unsigned N, unsigned K>
 __device__ void mma_kernel(Tout* data) {
   START
   mma_sync(sum, aFrag, bFrag, sum);
   END
 }
 
-template <typename Tin, typename Tout, unsigned M, unsigned N, unsigned K>
+template <typename Tin, typename Tc, typename Tout, unsigned M, unsigned N, unsigned K>
 __device__ void mma_kernel_ptx(Tout* data) {
   START
   mma_sync_ptx(sum, aFrag, bFrag, sum);
@@ -33,21 +33,21 @@ __device__ void mma_kernel_ptx(Tout* data) {
 }
 
 __global__ void mma_s8_16_16_16(void* data) {
-  mma_kernel<signed char, int, 16, 16, 16>((int*)data);
+  mma_kernel<signed char, signed char, int, 16, 16, 16>((int*)data);
 }
 
 __global__ void mma_f16_16_16_16(void* data) {
-  mma_kernel<half, float, 16, 16, 16>((float*)data);
+  mma_kernel<half, half, float, 16, 16, 16>((float*)data);
 }
 
 __global__ void mma_bf16_16_16_16(void* data) {
-  mma_kernel<hip_bfloat16, float, 16, 16, 16>((float*)data);
+  mma_kernel<hip_bfloat16, hip_bfloat16, float, 16, 16, 16>((float*)data);
 }
 
 __global__ void mma_f32_16_16_16(void* data) {
- mma_kernel<float, float, 16, 16, 16>((float*)data);
+ mma_kernel<float, float, float, 16, 16, 16>((float*)data);
 }
 
 __global__ void mma_f64_16_16_16(void* data) {
- mma_kernel<double, double, 16, 16, 16>((double*)data);
+ mma_kernel<double, double, double, 16, 16, 16>((double*)data);
 }

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -1,6 +1,8 @@
 #include <hip/hip_runtime.h>
 #include <rocwmma/rocwmma.hpp>
 
+#include "precision.h"
+
 using namespace rocwmma;
 
 #define REPEAT_COUNT 32768
@@ -25,11 +27,17 @@ __device__ void mma_kernel(Tout* data) {
   END
 }
 
+#include "mma_m16n16k32_fp32fp8fp8fp32.h"
+
 template <typename Tin, typename Tc, typename Tout, unsigned M, unsigned N, unsigned K>
-__device__ void mma_kernel_ptx(Tout* data) {
+__device__ void mma_kernel_llvm(Tout* data) {
   START
-  mma_sync_ptx(sum, aFrag, bFrag, sum);
+  mma_sync_llvm(sum, aFrag, bFrag, sum);
   END
+}
+
+__global__ void mma_fp8_16_16_32(void* data) {
+  mma_kernel_llvm<float, precision::fp8, float, 16, 16, 32>((float*)data);
 }
 
 __global__ void mma_s8_16_16_16(void* data) {

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -38,11 +38,11 @@ __device__ void mma_kernel_llvm(Tout* data) {
 }
 
 __global__ void mma_fp8_16_16_32(void* data) {
-  mma_kernel_llvm<char, precision::fp8, float, 16, 16, 32>((char*)data);
+  mma_kernel_llvm<char, precision::fp8, float, 16, 16, 32>((float*)data);
 }
 
 __global__ void mma_bf8_16_16_32(void* data) {
-  mma_kernel_llvm<char, precision::bf8, float, 16, 16, 32>((char*)data);
+  mma_kernel_llvm<char, precision::bf8, float, 16, 16, 32>((float*)data);
 }
 
 __global__ void mma_s8_16_16_32(void* data) {

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -28,6 +28,7 @@ __device__ void mma_kernel(Tout* data) {
 }
 
 #include "mma_m16n16k32_fp32fp8fp8fp32.h"
+#include "mma_m16n16k32_fp32bf8bf8fp32.h"
 
 template <typename Tin, typename Tmma, typename Tout, unsigned M, unsigned N, unsigned K>
 __device__ void mma_kernel_llvm(Tout* data) {
@@ -37,7 +38,11 @@ __device__ void mma_kernel_llvm(Tout* data) {
 }
 
 __global__ void mma_fp8_16_16_32(void* data) {
-  mma_kernel_llvm<float, precision::fp8, float, 16, 16, 32>((float*)data);
+  mma_kernel_llvm<char, precision::fp8, float, 16, 16, 32>((char*)data);
+}
+
+__global__ void mma_bf8_16_16_32(void* data) {
+  mma_kernel_llvm<char, precision::bf8, float, 16, 16, 32>((char*)data);
 }
 
 __global__ void mma_s8_16_16_32(void* data) {

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -40,8 +40,8 @@ __global__ void mma_fp8_16_16_32(void* data) {
   mma_kernel_llvm<float, precision::fp8, float, 16, 16, 32>((float*)data);
 }
 
-__global__ void mma_s8_16_16_16(void* data) {
-  mma_kernel<signed char, signed char, int, 16, 16, 16>((int*)data);
+__global__ void mma_s8_16_16_32(void* data) {
+  mma_kernel<signed char, signed char, int, 16, 16, 32>((int*)data);
 }
 
 __global__ void mma_f16_16_16_16(void* data) {

--- a/kernels/mma.hip
+++ b/kernels/mma.hip
@@ -9,8 +9,8 @@ using namespace rocwmma;
 
 #define START                                        \
   fragment<accumulator, M, N, K, Tout> sum;          \
-  fragment<matrix_a, M, N, K, Tc, row_major> aFrag; \
-  fragment<matrix_b, M, N, K, Tc, col_major> bFrag; \
+  fragment<matrix_a, M, N, K, Tmma, row_major> aFrag; \
+  fragment<matrix_b, M, N, K, Tmma, col_major> bFrag; \
   fill_fragment(sum, static_cast<Tout>(0));          \
   fill_fragment(aFrag, static_cast<Tin>(0));         \
   fill_fragment(bFrag, static_cast<Tin>(0));         \
@@ -20,7 +20,7 @@ using namespace rocwmma;
   Tout* ptr = &data[threadIdx.y * M * N]; \
   store_matrix_sync(ptr, sum, N, mem_row_major);
 
-template <typename Tin, typename Tc, typename Tout, unsigned M, unsigned N, unsigned K>
+template <typename Tin, typename Tmma, typename Tout, unsigned M, unsigned N, unsigned K>
 __device__ void mma_kernel(Tout* data) {
   START
   mma_sync(sum, aFrag, bFrag, sum);
@@ -29,7 +29,7 @@ __device__ void mma_kernel(Tout* data) {
 
 #include "mma_m16n16k32_fp32fp8fp8fp32.h"
 
-template <typename Tin, typename Tc, typename Tout, unsigned M, unsigned N, unsigned K>
+template <typename Tin, typename Tmma, typename Tout, unsigned M, unsigned N, unsigned K>
 __device__ void mma_kernel_llvm(Tout* data) {
   START
   mma_sync_llvm(sum, aFrag, bFrag, sum);

--- a/kernels/mma_m16n16k32_fp32bf8bf8fp32.h
+++ b/kernels/mma_m16n16k32_fp32bf8bf8fp32.h
@@ -1,0 +1,40 @@
+#include <rocwmma/rocwmma.hpp>
+
+#include "precision.h"
+
+using namespace rocwmma;
+
+
+template<>
+class __align__(4) fragment<matrix_a, 16, 16, 32, precision::bf8, row_major> {
+  public:
+    const static size_t num_elements = 2;
+    VRegF32x2 regs;
+};
+
+template<>
+class __align__(4) fragment<matrix_b, 16, 16, 32, precision::bf8, col_major> {
+  public:
+    const static size_t num_elements = 2;
+    VRegF32x2 regs;
+};
+
+template<typename MatrixT, typename DataLayout>
+__device__ void fill_fragment(fragment<MatrixT, 16, 16, 32, precision::bf8, DataLayout>& frag, const char value) {
+    for (size_t i = 0; i < frag.num_elements; i++) {
+        frag.regs.data[i] = value | (value << 8) | (value << 16) | (value << 24);
+    }
+}
+
+// MFMA compiler intrinsic syntax:
+// https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-matrix-cores-readme/#mfma-compiler-intrinsic-syntax
+inline __device__ void mma_sync_llvm(
+  fragment<accumulator, 16, 16, 32, float>& d,
+  const fragment<matrix_a, 16, 16, 32, precision::bf8, row_major>& a,
+  const fragment<matrix_b, 16, 16, 32, precision::bf8, col_major>& b,
+  const fragment<accumulator, 16, 16, 32, float>& c) {
+
+#if __gfx940__ || __gfx941__ || __gfx942__
+  (*d).data = __builtin_amdgcn_mfma_f32_16x16x32_bf8_bf8(((VRegI64x1 const&)(a.regs)).data[0], ((VRegI64x1 const&)(b.regs)).data[0], (*c).data, 0, 0, 0);
+#endif
+}

--- a/kernels/mma_m16n16k32_fp32bf8bf8fp32.h
+++ b/kernels/mma_m16n16k32_fp32bf8bf8fp32.h
@@ -4,7 +4,6 @@
 
 using namespace rocwmma;
 
-
 template<>
 class __align__(4) fragment<matrix_a, 16, 16, 32, precision::bf8, row_major> {
   public:
@@ -23,6 +22,42 @@ template<typename MatrixT, typename DataLayout>
 __device__ void fill_fragment(fragment<MatrixT, 16, 16, 32, precision::bf8, DataLayout>& frag, const char value) {
     for (size_t i = 0; i < frag.num_elements; i++) {
         frag.regs.data[i] = value | (value << 8) | (value << 16) | (value << 24);
+    }
+}
+
+__device__ void load_matrix_sync(fragment<matrix_a, 16, 16, 32, precision::bf8, row_major>& frag, const char* ptr, unsigned ldm) {
+    // A i: (lane % 16)
+    // A k: 8 * floor(lane / 16) + 4 * GPR_num + floor(GPR_bits / 8)
+    const unsigned lane = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
+    const unsigned i = lane % 16;
+    const unsigned epr = 4;  // 4 elements per register (4 chars in one 32-bit register)
+    for (size_t reg = 0; reg < frag.num_elements; reg++) {
+        frag.regs.data[reg] = 0;
+        int tmp = 0;
+        for (size_t ele = 0; ele < epr; ele++) {
+            unsigned k = frag.num_elements * epr * (lane / 16) + epr * reg + ele;
+            char value = ptr[i * ldm + k];
+            tmp |= value << (8 * ele);
+        }
+        frag.regs.data[reg] = *reinterpret_cast<float *>(&tmp);
+    }
+}
+
+__device__ void load_matrix_sync(fragment<matrix_b, 16, 16, 32, precision::bf8, col_major>& frag, const char* ptr, unsigned ldm) {
+    // B j: (lane % 16)
+    // B k: 8 * floor(lane / 16) + 4 * GPR_num + floor(GPR_bits / 8)
+    const unsigned lane = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
+    const unsigned j = lane % 16;
+    const unsigned epr = 4;  // 4 elements per register (4 chars in one 32-bit register)s
+    for (size_t reg = 0; reg < frag.num_elements; reg++) {
+        frag.regs.data[reg] = 0;
+        int tmp = 0;
+        for (size_t ele = 0; ele < epr; ele++) {
+            unsigned k = frag.num_elements * epr * (lane / 16) + epr * reg + ele;
+            char value = ptr[j * ldm + k];
+            tmp |= value << (8 * ele);
+        }
+        frag.regs.data[reg] = *reinterpret_cast<float *>(&tmp);
     }
 }
 

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -1,0 +1,56 @@
+#include <rocwmma/rocwmma.hpp>
+
+#include "precision.h"
+
+using namespace rocwmma;
+
+
+template<>
+class __align__(4) fragment<matrix_a, 16, 16, 32, precision::fp8, row_major> {
+  public:
+    const static size_t num_elements = 2;
+    VRegF32x2 regs;
+};
+
+template<>
+class __align__(4) fragment<matrix_b, 16, 16, 32, precision::fp8, col_major> {
+  public:
+    const static size_t num_elements = 2;
+    VRegF32x2 regs;
+};
+
+template<typename MatrixT, typename DataLayout>
+__device__ void fill_fragment(fragment<MatrixT, 16, 16, 32, precision::fp8, DataLayout>& frag, float value) {
+  for (size_t i = 0; i < frag.num_elements; i++) {
+    frag.regs.data[i] = value;
+  }
+}
+
+// https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-matrix-cores-readme/#mfma-compiler-intrinsic-syntax
+inline __device__ void mma_sync_llvm(
+  fragment<accumulator, 16, 16, 32, float>& d,
+  const fragment<matrix_a, 16, 16, 32, precision::fp8, row_major>& a,
+  const fragment<matrix_b, 16, 16, 32, precision::fp8, col_major>& b,
+  const fragment<accumulator, 16, 16, 32, float>& c) {
+
+  const size_t M = 16;
+  const size_t N = 16;
+  const size_t K = 32;
+  const size_t output_elements_per_thread = M * N / 64; // wave size 64 assumed
+
+  size_t mk = threadIdx.y + K * threadIdx.x;
+  size_t kn = threadIdx.x + N * threadIdx.y;
+
+  long amk = a.regs.data[mk];
+  long bkn = b.regs.data[kn];
+  VecT<float, 4> dmn;
+  VecT<float, 4> cmn; // todo: what to put for C here?
+#if __gfx940__ || __gfx941__ || __gfx942__
+  dmn.data = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(amk, bkn, cmn.data, 0, 0, 0);
+#endif
+
+  for (size_t i = 0; i < output_elements_per_thread; i++) {
+    const int idx = threadIdx.x + i * N + threadIdx.y * 4 * N;
+    (*d).data[idx] = dmn.data[i];
+  }
+}

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -37,10 +37,10 @@ inline __device__ void mma_sync_llvm(
   const size_t M = 16;
   const size_t N = 16;
   const size_t K = 32;
-  const size_t output_elements_per_thread = M * N / 64; // wave size 64 assumed
+  const size_t output_elements_per_thread = M * N / __AMDGCN_WAVEFRONT_SIZE__;
 
-  size_t tid_x = threadIdx.x % 64;
-  size_t tid_y = threadIdx.x / 64;
+  size_t tid_x = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
+  size_t tid_y = threadIdx.x / __AMDGCN_WAVEFRONT_SIZE__;
 
   size_t mk = tid_y + K * tix_x;
   size_t kn = tid_x + N * tid_y;

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -38,8 +38,11 @@ inline __device__ void mma_sync_llvm(
   const size_t K = 32;
   const size_t output_elements_per_thread = M * N / 64; // wave size 64 assumed
 
-  size_t mk = threadIdx.y + K * threadIdx.x;
-  size_t kn = threadIdx.x + N * threadIdx.y;
+  size_t tid_x = threadIdx.x % 64;
+  size_t tid_y = threadIdx.x / 64;
+
+  size_t mk = tid_y + K * tix_x;
+  size_t kn = tid_x + N * tid_y;
 
   long amk = a.regs.data[mk];
   long bkn = b.regs.data[kn];
@@ -50,7 +53,7 @@ inline __device__ void mma_sync_llvm(
 #endif
 
   for (size_t i = 0; i < output_elements_per_thread; i++) {
-    const int idx = threadIdx.x + i * N + threadIdx.y * 4 * N;
+    const int idx = tid_x + i * N + tid_y * output_elements_per_thread * N;
     (*d).data[idx] = dmn.data[i];
   }
 }

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -26,6 +26,7 @@ __device__ void fill_fragment(fragment<MatrixT, 16, 16, 32, precision::fp8, Data
   }
 }
 
+// MFMA compiler intrinsic syntax:
 // https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-matrix-cores-readme/#mfma-compiler-intrinsic-syntax
 inline __device__ void mma_sync_llvm(
   fragment<accumulator, 16, 16, 32, float>& d,

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -4,7 +4,6 @@
 
 using namespace rocwmma;
 
-
 template<>
 class __align__(4) fragment<matrix_a, 16, 16, 32, precision::fp8, row_major> {
   public:
@@ -23,6 +22,42 @@ template<typename MatrixT, typename DataLayout>
 __device__ void fill_fragment(fragment<MatrixT, 16, 16, 32, precision::fp8, DataLayout>& frag, const char value) {
     for (size_t i = 0; i < frag.num_elements; i++) {
         frag.regs.data[i] = value | (value << 8) | (value << 16) | (value << 24);
+    }
+}
+
+__device__ void load_matrix_sync(fragment<matrix_a, 16, 16, 32, precision::fp8, row_major>& frag, const char* ptr, unsigned ldm) {
+    // A i: (lane % 16)
+    // A k: 8 * floor(lane / 16) + 4 * GPR_num + floor(GPR_bits / 8)
+    const unsigned lane = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
+    const unsigned i = lane % 16;
+    const unsigned epr = 4;  // 4 elements per register (4 chars in one 32-bit register)
+    for (size_t reg = 0; reg < frag.num_elements; reg++) {
+        frag.regs.data[reg] = 0;
+        int tmp = 0;
+        for (size_t ele = 0; ele < epr; ele++) {
+            unsigned k = frag.num_elements * epr * (lane / 16) + epr * reg + ele;
+            char value = ptr[i * ldm + k];
+            tmp |= value << (8 * ele);
+        }
+        frag.regs.data[reg] = *reinterpret_cast<float *>(&tmp);
+    }
+}
+
+__device__ void load_matrix_sync(fragment<matrix_b, 16, 16, 32, precision::fp8, col_major>& frag, const char* ptr, unsigned ldm) {
+    // B j: (lane % 16)
+    // B k: 8 * floor(lane / 16) + 4 * GPR_num + floor(GPR_bits / 8)
+    const unsigned lane = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
+    const unsigned j = lane % 16;
+    const unsigned epr = 4;  // 4 elements per register (4 chars in one 32-bit register)s
+    for (size_t reg = 0; reg < frag.num_elements; reg++) {
+        frag.regs.data[reg] = 0;
+        int tmp = 0;
+        for (size_t ele = 0; ele < epr; ele++) {
+            unsigned k = frag.num_elements * epr * (lane / 16) + epr * reg + ele;
+            char value = ptr[j * ldm + k];
+            tmp |= value << (8 * ele);
+        }
+        frag.regs.data[reg] = *reinterpret_cast<float *>(&tmp);
     }
 }
 

--- a/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
+++ b/kernels/mma_m16n16k32_fp32fp8fp8fp32.h
@@ -42,13 +42,13 @@ inline __device__ void mma_sync_llvm(
   size_t tid_x = threadIdx.x % __AMDGCN_WAVEFRONT_SIZE__;
   size_t tid_y = threadIdx.x / __AMDGCN_WAVEFRONT_SIZE__;
 
-  size_t mk = tid_y + K * tix_x;
+  size_t mk = tid_y + K * tid_x;
   size_t kn = tid_x + N * tid_y;
 
   long amk = a.regs.data[mk];
   long bkn = b.regs.data[kn];
   VecT<float, 4> dmn;
-  VecT<float, 4> cmn; // todo: what to put for C here?
+  VecT<float, 4> cmn{0, 0, 0, 0}; // todo: what to put for C here?
 #if __gfx940__ || __gfx941__ || __gfx942__
   dmn.data = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(amk, bkn, cmn.data, 0, 0, 0);
 #endif

--- a/kernels/precision.h
+++ b/kernels/precision.h
@@ -1,0 +1,9 @@
+#ifndef PRECISION_H
+#define PRECISION_H
+
+namespace precision {
+  struct fp8; // e4m3
+  struct bf8; // e5m2
+}
+
+#endif // PRECISION_H

--- a/kernels/precision.h
+++ b/kernels/precision.h
@@ -1,6 +1,8 @@
 #ifndef PRECISION_H
 #define PRECISION_H
 
+// For an explanation of AMD's implementation of fp8 and bf8, see
+// https://github.com/ROCm/amd_matrix_instruction_calculator/blob/dae289b7/matrix_calculator.py#L150
 namespace precision {
   struct fp8; // e4m3
   struct bf8; // e5m2

--- a/mma.hip
+++ b/mma.hip
@@ -1,6 +1,7 @@
 #include "common.h"
 
 __global__ void mma_fp8_16_16_32(void* ptr);
+__global__ void mma_bf8_16_16_32(void* ptr);
 __global__ void mma_s8_16_16_32(void* ptr);
 __global__ void mma_f16_16_16_16(void* ptr);
 __global__ void mma_bf16_16_16_16(void* ptr);

--- a/mma.hip
+++ b/mma.hip
@@ -38,10 +38,13 @@ int main(int argc, const char* argv[]) {
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
     benchmark.run(reinterpret_cast<void*>(&mma_bf16_16_16_16), grid, block,
                   "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
-    // F32 and F64 are only available on CDNA (gfx9)
-    if (benchmark.isGfx9()) {
+    // F32 is only available on CDNA
+    if (benchmark.isCDNA()) {
         benchmark.run(reinterpret_cast<void*>(&mma_f32_16_16_16 ), grid, block,
                       "mma_f32_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    }
+    // F64 is only available on CDNA2+
+    if (benchmark.isCDNA2() || benchmark.isCDNA3()) {
         benchmark.run(reinterpret_cast<void*>(&mma_f64_16_16_16 ), grid, block,
                       "mma_f64_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
     }

--- a/mma.hip
+++ b/mma.hip
@@ -53,6 +53,8 @@ int main(int argc, const char* argv[]) {
     if (benchmark.isCDNA3()) {
         benchmark.run(reinterpret_cast<void*>(&mma_fp8_16_16_32 ), grid, block,
                       "mma_fp8_16_16_32", gops * (16 * 16 * 32 * 2), gbytes);
+        benchmark.run(reinterpret_cast<void*>(&mma_bf8_16_16_32 ), grid, block,
+                      "mma_bf8_16_16_32", gops * (16 * 16 * 32 * 2), gbytes);
     }
   }
 

--- a/mma.hip
+++ b/mma.hip
@@ -1,5 +1,6 @@
 #include "common.h"
 
+__global__ void mma_fp8_16_16_32(void* ptr);
 __global__ void mma_s8_16_16_16(void* ptr);
 __global__ void mma_f16_16_16_16(void* ptr);
 __global__ void mma_bf16_16_16_16(void* ptr);
@@ -47,6 +48,11 @@ int main(int argc, const char* argv[]) {
     if (benchmark.isCDNA2() || benchmark.isCDNA3()) {
         benchmark.run(reinterpret_cast<void*>(&mma_f64_16_16_16 ), grid, block,
                       "mma_f64_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    }
+    // FP8 / BF8 are only available on CDNA3
+    if (benchmark.isCDNA3()) {
+        benchmark.run(reinterpret_cast<void*>(&mma_fp8_16_16_32 ), grid, block,
+                      "mma_fp8_16_16_32", gops * (16 * 16 * 32 * 2), gbytes);
     }
   }
 

--- a/mma.hip
+++ b/mma.hip
@@ -1,7 +1,7 @@
 #include "common.h"
 
 __global__ void mma_fp8_16_16_32(void* ptr);
-__global__ void mma_s8_16_16_16(void* ptr);
+__global__ void mma_s8_16_16_32(void* ptr);
 __global__ void mma_f16_16_16_16(void* ptr);
 __global__ void mma_bf16_16_16_16(void* ptr);
 __global__ void mma_f32_16_16_16(void* ptr);
@@ -33,8 +33,8 @@ int main(int argc, const char* argv[]) {
 
   // Run benchmark
   for (int i = 0; i < benchmark.nrBenchmarks(); i++) {
-    benchmark.run(reinterpret_cast<void*>(&mma_s8_16_16_16), grid, block,
-                  "mma_s8_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    benchmark.run(reinterpret_cast<void*>(&mma_s8_16_16_32), grid, block,
+                  "mma_s8_16_16_32", gops * (16 * 16 * 32 * 2), gbytes);
     benchmark.run(reinterpret_cast<void*>(&mma_f16_16_16_16), grid, block,
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
     benchmark.run(reinterpret_cast<void*>(&mma_bf16_16_16_16), grid, block,


### PR DESCRIPTION
The code compiles, but we can only run it on a CDNA3 GPU so it has not been tested yet.
the mma_sync implementation is based on https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-matrix-cores-readme/#mfma-compiler-intrinsic-syntax. It may not be exactly right, although performance measurements should be fair.

When this is verified to work, we could add bf8 as well