### PR TITLE
Update CMake for rocwmma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ endif()
 
 find_package(hip REQUIRED)
 
+find_package(rocwmma REQUIRED)
+
 include(FetchContent)
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ if(NOT CMAKE_HIP_ARCHITECTURES)
       CACHE STRING "HIP architecture")
 endif()
 
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
 find_package(hip REQUIRED)
 
 find_package(rocwmma REQUIRED)

--- a/cmake/Findrocwmma.cmake
+++ b/cmake/Findrocwmma.cmake
@@ -1,0 +1,16 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(
+  ROCWMMA_INCLUDE_DIR
+  NAMES rocwmma/rocwmma.hpp
+  PATHS /usr/local/include /usr/include)
+
+find_package_handle_standard_args(
+  rocwmma
+  REQUIRED_VARS ROCWMMA_INCLUDE_DIR
+  VERSION_VAR ROCWMMA_VERSION)
+
+if(NOT TARGET rocwmma)
+  add_library(rocwmma INTERFACE)
+  target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+endif()

--- a/cmake/Findrocwmma.cmake
+++ b/cmake/Findrocwmma.cmake
@@ -2,8 +2,7 @@ include(FindPackageHandleStandardArgs)
 
 find_path(
   ROCWMMA_INCLUDE_DIR
-  NAMES rocwmma/rocwmma.hpp
-  PATHS /usr/local/include /usr/include)
+  NAMES rocwmma/rocwmma.hpp)
 
 find_package_handle_standard_args(
   rocwmma


### PR DESCRIPTION
A `Findrocwmma.cmake` helper file was added, which is used to make sure that the header-only rocwmma is found at cmake configure time.

Note that there is no `target_link_libraries(<target> rocwmma)`, since in practice rocwmma is installed in the `/include` of ROCM, such that it is always found when compiling with `hipcc`.